### PR TITLE
Adding restrictions to scopedAction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-scope-utils",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1863,6 +1863,21 @@
       "dev": true,
       "requires": {
         "locate-path": "^2.0.0"
+      }
+    },
+    "flux-standard-action": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/flux-standard-action/-/flux-standard-action-2.1.1.tgz",
+      "integrity": "sha512-W86GzmXmIiTVq/dpYVd2HtTIUX9c35Iq3ao3xR6qcKtuXgbu+BDEj72op5VnEIe/kpuSbhl+I8kT1iS2hpcusw==",
+      "requires": {
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "for-in": {

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "jest": "^23.6.0",
     "prettier": "^1.15.2",
     "redux": "^4.0.1"
+  },
+  "dependencies": {
+    "flux-standard-action": "^2.1.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
-import * as typed from './typed';
-export { typed };
+import { isFSA } from 'flux-standard-action';
 
 /**
  * Utility to grab a slice of the state based on the scope
@@ -17,16 +16,23 @@ export const getStateSlice = (state, scope) => {
  * Creates an action creator with predefined scope. This allows generic
  * action creators to be created for a specific part of state.
  *
- * @param {function} actionCreator - Function which creates an action. The `scope` must
- *                                  be the last param.
+ * @param {function} actionCreator - Function which creates an action or a valid action object
  * @param {string} scope - State path
  * @return {function} Scoped action creator
  */
-export const scopedAction = (actionCreator, scope) =>
-  (...args) => ({
-    ...actionCreator(...args),
-    meta: { ...actionCreator(...args).meta, scope }
-  })
+export const scopedAction = (actionCreator, scope) => (...args) => {
+  const action =
+    typeof actionCreator === 'function'
+      ? actionCreator(...args)
+      : actionCreator;
+
+  if (!isFSA(action)) return actionCreator;
+
+  return {
+    ...action,
+    meta: { ...action.meta, scope }
+  };
+};
 
 /**
  * Create a selector with a predefined scope. This allows generic selectors

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -1,35 +1,65 @@
-import { combineReducers } from 'redux'
-import { scopedAction } from '../src'
+import { scopedAction } from '../src';
 
 describe('scopedAction', () => {
   it('Creates an action creator with a scope', () => {
     const setValue = val => ({
       type: 'SET_VALUE',
       payload: val
-    })
+    });
 
-    const scopedSetValue = scopedAction(setValue, 'abc')
+    const scopedSetValue = scopedAction(setValue, 'abc');
 
     expect(scopedSetValue('hello')).toEqual({
       type: 'SET_VALUE',
       payload: 'hello',
       meta: { scope: 'abc' }
-    })
-  })
+    });
+  });
 
   it('Maintains meta properties', () => {
     const setValue = val => ({
       type: 'SET_VALUE',
       payload: val,
       meta: { timestamp: 0 }
-    })
+    });
 
-    const scopedSetValue = scopedAction(setValue, 'abc')
+    const scopedSetValue = scopedAction(setValue, 'abc');
 
     expect(scopedSetValue('hello')).toEqual({
       type: 'SET_VALUE',
       payload: 'hello',
       meta: { scope: 'abc', timestamp: 0 }
-    })
-  })
-})
+    });
+  });
+
+  it('Ignores non standard action types', () => {
+    const stringAction = 'STR';
+    const scopedString = scopedAction(stringAction, 'abc');
+
+    expect(scopedString()).toEqual(stringAction);
+
+    const thunk = jest.fn(val => dispatch => dispatch(val * 2));
+
+    const scopedThunk = scopedAction(thunk, 'abc');
+    expect(scopedThunk()).toEqual(thunk);
+
+    expect(scopedThunk(2)).toBeCalledWith(2);
+    expect(scopedThunk(4)).toHaveLastReturnedWith(8);
+  });
+
+  it.only('Scopes valid objects', () => {
+    const objAction = {
+      type: 'SET_VALUE',
+      payload: 'hello'
+    };
+
+    const scopedObject = scopedAction(objAction, 'abc');
+
+    expect(scopedObject()).toEqual({
+      ...objAction,
+      meta: {
+        scope: 'abc'
+      }
+    });
+  });
+});


### PR DESCRIPTION
Updating `scopedAction` so that it only scopes an action creator or an action object. Also adding validation that the object is an FSA.